### PR TITLE
Only heal player if entity takes damage

### DIFF
--- a/battlegear mod src/minecraft/mods/battlegear2/items/arrows/EntityLeechArrow.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/items/arrows/EntityLeechArrow.java
@@ -32,9 +32,10 @@ public class EntityLeechArrow extends AbstractMBArrow{
     public boolean onHitEntity(Entity entityHit, DamageSource source, float ammount) {
         if(shootingEntity instanceof EntityLivingBase && entityHit instanceof EntityLivingBase){
             float value = ((EntityLivingBase) entityHit).getHealth()* 0.2F;//Leech 20% of opponent life
-            ((EntityLivingBase) shootingEntity).heal(value);
-            entityHit.attackEntityFrom(DamageSource.causeThornsDamage(shootingEntity), value);
-            ((EntityLivingBase) entityHit).addPotionEffect(new PotionEffect(Potion.weakness.getId(), 40));//Weaken the opponent
+            if (entityHit.attackEntityFrom(DamageSource.causeThornsDamage(shootingEntity), value)) {
+                ((EntityLivingBase) shootingEntity).heal(value);
+                ((EntityLivingBase) entityHit).addPotionEffect(new PotionEffect(Potion.weakness.getId(), 40));//Weaken the opponent
+            }
             ((EntityLivingBase) entityHit).setArrowCountInEntity(((EntityLivingBase) entityHit).getArrowCountInEntity()+1);
             this.setDead();
             return true;


### PR DESCRIPTION
Typically secondary effects only occur when an entity is actually damaged; this will also prevent players from exploiting the leech / heal effect on invulnerable entities, if those exist
