### PR TITLE
Update EntityPlayer.java.patch

### DIFF
--- a/battlegear mod src/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/battlegear mod src/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -36,7 +36,7 @@
       * Inventory of the player
       */
 -    public InventoryPlayer inventory = new InventoryPlayer(this);
-+    public final InventoryPlayer inventory = new InventoryPlayerBattle(this);
++    public InventoryPlayer inventory = new InventoryPlayerBattle(this);
      private InventoryEnderChest theInventoryEnderChest = new InventoryEnderChest();
      /**
       * The Container for the player's inventory (which opens when they press E)


### PR DESCRIPTION
Drones in PneumaticCraft use fake players. After the first initialization it sets the inventory of this fake player to an other. When installed with Battlegear 2 this will cause a crash because of the 'final' marked field. I know Battlegear 2 is doing this to prevent other mods messing with the player's inventory, but could an exception be made for fake players?

Tnx!

MineMaarten
