### PR TITLE
Make DefaultArrowFire class public

### DIFF
--- a/battlegear mod src/minecraft/mods/battlegear2/api/quiver/QuiverArrowRegistry.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/api/quiver/QuiverArrowRegistry.java
@@ -219,7 +219,7 @@ public class QuiverArrowRegistry {
      * from registered class, with the (World, EntityLivingBase, float) constructor
      * If the arrow is unknown, the registered class is null or the constructor isn't valid, defers to other firing handlers silently
      */
-    static class DefaultArrowFire implements IArrowFireHandler{
+    public static class DefaultArrowFire implements IArrowFireHandler {
 
         @Override
         public boolean canFireArrow(ItemStack arrow, World world, EntityPlayer player, float charge) {


### PR DESCRIPTION
Just realized there was no way to add the default fire handler when using ISpecialBow#getFireHandlers.
