### PR TITLE
Use SRG names in ASM (also Minecraft Forkage compatibility)

### DIFF
--- a/battlegear mod src/minecraft/mods/battlegear2/Battlegear.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/Battlegear.java
@@ -49,7 +49,6 @@ public class Battlegear {
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         //Set up the Translator
-        BattlegearTranslator.setup("/deobfuscation_data-" + FMLInjectionData.data()[4] + ".lzma");
         knightArmourMaterial = EnumHelper.addArmorMaterial("knights.armour", 25, new int[]{3, 7, 5, 3}, 15);
         BattlegearConfig.getConfig(new Configuration(event.getSuggestedConfigurationFile()));
 

--- a/battlegear mod src/minecraft/mods/battlegear2/api/core/BattlegearTranslator.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/api/core/BattlegearTranslator.java
@@ -1,158 +1,27 @@
 package mods.battlegear2.api.core;
 
-import com.google.common.base.Charsets;
-import cpw.mods.fml.common.asm.transformers.deobf.LZMAInputSupplier;
-import cpw.mods.fml.relauncher.FMLInjectionData;
-import cpw.mods.fml.relauncher.IFMLCallHook;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 /**
  * Core Translator for Battlegear Coremod and Reflection usage
  * Allows to run Battlegear in both deobfuscated and obfuscated environment
  */
-public class BattlegearTranslator implements IFMLCallHook {
+public class BattlegearTranslator {
     //Setting this to true will enable the output of all edited classes as .class files
     public static boolean debug = false;
     public static boolean obfuscatedEnv;
-
-    private String deobFile;
-    private String mcLocation;
     
-    private static HashMap<String, String> classNameMap = new HashMap<String, String>();
-    private static HashMap<String, String> fieldNameMap = new HashMap<String, String>();
-    private static HashMap<String, String> methodNameMap = new HashMap<String, String>();
-    private static HashMap<String, String> methodDescMap = new HashMap<String, String>();
-
     public static String getMapedFieldName(String className, String fieldName, String devName) {
-        //return obfuscatedEnv?fieldNameMap.get(className + "." + fieldName):devName;
     	return obfuscatedEnv?fieldName:devName;
     }
 
     public static String getMapedClassName(String className) {
-    	//if(obfuscatedEnv)
-    	//	return classNameMap.get(className.substring(className.lastIndexOf(".")+1));
-    	//else{
-    		return new StringBuilder("net/minecraft/").append(className.replace(".", "/")).toString();
-    	//}
+    	return new StringBuilder("net/minecraft/").append(className.replace(".", "/")).toString();
     }
 
     public static String getMapedMethodName(String className, String methodName, String devName) {
-        //return obfuscatedEnv?methodNameMap.get(className + "." + methodName):devName;
     	return obfuscatedEnv?methodName:devName;
     }
 
     public static String getMapedMethodDesc(String className, String methodName, String devDesc) {
-        //return obfuscatedEnv?methodDescMap.get(className + "." + methodName):devDesc;
     	return devDesc;
     }
-
-    public static void setup(String deobFileName){
-        try{
-            LZMAInputSupplier zis = new LZMAInputSupplier(FMLInjectionData.class.getResourceAsStream(deobFileName));
-            List<String> srgList = zis.asCharSource(Charsets.UTF_8).readLines();
-
-            for (String line : srgList) {
-
-                line = line.replace(" #C", "").replace(" #S", "");
-
-                if (line.startsWith("CL")) {
-                    parseClass(line);
-                } else if (line.startsWith("FD")) {
-                    parseField(line);
-                } else if (line.startsWith("MD")) {
-                    parseMethod(line);
-                }
-
-            }
-
-
-        }catch(Exception e){
-            e.printStackTrace();
-        }
-    }
-
-    @Override
-    public Void call() throws Exception {
-        setup(deobFile);
-        //parse the config file
-        File config = new File(mcLocation+File.separator+"config"+File.separator+"battlegear2.cfg");
-        config.getParentFile().mkdirs();
-        if(config.createNewFile() || config.exists()){
-        	readConfig(config);
-        }
-        
-        return null;
-    }
-
-    private void readConfig(File config) {
-    	BufferedReader br = null;
-    	try{
-    		br = new BufferedReader(new FileReader(config));
-    		String line = br.readLine();
-
-    		while(line != null){
-    			if(line.toLowerCase(Locale.ENGLISH).contains("asm debug mode")){
-    				debug = line.toLowerCase(Locale.ENGLISH).contains("true");
-                    break;
-    			}
-    			line = br.readLine();
-    		}
-    	}catch(Exception e){
-    		e.printStackTrace();
-    	} finally{
-    		if(br != null){
-    			try{
-    				br.close();
-    			}catch (Exception e2){
-    				e2.printStackTrace();
-    			}
-    		}
-    	}
-	}
-
-	private static void parseMethod(String line) {
-        String[] splitLine = line.split(" ");
-
-        String[] splitObName = splitLine[1].split("/");
-        String[] splitTranslatedName = splitLine[3].split("/");
-
-        String key = splitTranslatedName[splitTranslatedName.length - 2] + "." + splitTranslatedName[splitTranslatedName.length - 1];
-
-        methodNameMap.put(key, splitObName[splitObName.length - 1]);
-
-        methodDescMap.put(key, splitLine[2]);
-    }
-
-    private static void parseField(String line) {
-        String[] splitLine = line.split(" ");
-
-        String[] splitObName = splitLine[1].split("/");
-        String[] splitTranslatedName = splitLine[2].split("/");
-
-        String key = splitTranslatedName[splitTranslatedName.length - 2] + "." + splitTranslatedName[splitTranslatedName.length - 1];
-
-        fieldNameMap.put(key, splitObName[splitObName.length - 1]);
-    }
-
-    private static void parseClass(String line) {
-        String[] splitLine = line.split(" ");
-
-        String[] splitClassPath = splitLine[2].split("/");
-
-        classNameMap.put(splitClassPath[splitClassPath.length - 1], splitLine[1]);
-    }
-
-    @Override
-    public void injectData(Map<String, Object> data) {
-        deobFile = data.get("deobfuscationFileName").toString();
-        mcLocation = data.get("mcLocation").toString();
-    }
-
 }

--- a/battlegear mod src/minecraft/mods/battlegear2/api/core/BattlegearTranslator.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/api/core/BattlegearTranslator.java
@@ -31,23 +31,26 @@ public class BattlegearTranslator implements IFMLCallHook {
     private static HashMap<String, String> methodDescMap = new HashMap<String, String>();
 
     public static String getMapedFieldName(String className, String fieldName, String devName) {
-        return obfuscatedEnv?fieldNameMap.get(className + "." + fieldName):devName;
+        //return obfuscatedEnv?fieldNameMap.get(className + "." + fieldName):devName;
+    	return obfuscatedEnv?fieldName:devName;
     }
 
     public static String getMapedClassName(String className) {
-    	if(obfuscatedEnv)
-    		return classNameMap.get(className.substring(className.lastIndexOf(".")+1));
-    	else{
+    	//if(obfuscatedEnv)
+    	//	return classNameMap.get(className.substring(className.lastIndexOf(".")+1));
+    	//else{
     		return new StringBuilder("net/minecraft/").append(className.replace(".", "/")).toString();
-    	}
+    	//}
     }
 
     public static String getMapedMethodName(String className, String methodName, String devName) {
-        return obfuscatedEnv?methodNameMap.get(className + "." + methodName):devName;
+        //return obfuscatedEnv?methodNameMap.get(className + "." + methodName):devName;
+    	return obfuscatedEnv?methodName:devName;
     }
 
     public static String getMapedMethodDesc(String className, String methodName, String devDesc) {
-        return obfuscatedEnv?methodDescMap.get(className + "." + methodName):devDesc;
+        //return obfuscatedEnv?methodDescMap.get(className + "." + methodName):devDesc;
+    	return devDesc;
     }
 
     public static void setup(String deobFileName){

--- a/battlegear mod src/minecraft/mods/battlegear2/coremod/BattlegearLoadingPlugin.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/coremod/BattlegearLoadingPlugin.java
@@ -59,7 +59,7 @@ public final class BattlegearLoadingPlugin implements IFMLLoadingPlugin {
 
     @Override
     public String getSetupClass() {
-        return "mods.battlegear2.api.core.BattlegearTranslator";
+        return null;
     }
 
     @Override

--- a/battlegear mod src/minecraft/mods/battlegear2/coremod/BattlegearLoadingPlugin.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/coremod/BattlegearLoadingPlugin.java
@@ -2,6 +2,7 @@ package mods.battlegear2.coremod;
 
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.Name;
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 import mods.battlegear2.api.core.BattlegearTranslator;
 
@@ -10,6 +11,7 @@ import java.util.Map;
 
 @TransformerExclusions({"mods.battlegear2.coremod"})
 @Name("Mine and Blade: Battlegear2")
+@SortingIndex(1500)
 public final class BattlegearLoadingPlugin implements IFMLLoadingPlugin {
 
     public static final String EntityPlayerTransformer = "mods.battlegear2.coremod.transformers.EntityPlayerTransformer";

--- a/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/NetServerHandlerTransformer.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/NetServerHandlerTransformer.java
@@ -86,7 +86,7 @@ public final class NetServerHandlerTransformer extends TransformerBase {
                         nextNode = it.next();
                     }
 
-    //BattlegearUtils.setPlayerCurrentItem(playerEntity, ItemStack.copyItemStack(this.playerEntity.inventory.getCurrentItem()));
+    //BattlegearUtils.setPlayerCurrentItem(playerEntity, ItemStack.copyItemStack(this.playerEntity.inventory.getCurrentItem().copy()));
                     newList.add(new VarInsnNode(ALOAD, 0));
                     newList.add(new FieldInsnNode(GETFIELD, netServiceHandelerClassName, netServiceHandelerPlayerField, "L" + entityPlayerMPClassName + ";"));
                     newList.add(new FieldInsnNode(GETFIELD, entityPlayerMPClassName, playerInventoryFieldName, "L" + inventoryPlayerClassName + ";"));
@@ -112,6 +112,7 @@ public final class NetServerHandlerTransformer extends TransformerBase {
                         if(nextNode instanceof LineNumberNode && slotIndex!=0) {
                             int line = ((LineNumberNode) nextNode).line;
                             LabelNode L0 = new LabelNode();
+                            // if(slot == null) return;
                             newList.add(new VarInsnNode(ALOAD, slotIndex));
                             newList.add(new JumpInsnNode(IFNONNULL, L0));
                             newList.add(new InsnNode(RETURN));

--- a/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/NetServerHandlerTransformer.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/NetServerHandlerTransformer.java
@@ -2,6 +2,8 @@ package mods.battlegear2.coremod.transformers;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import mods.battlegear2.api.core.BattlegearTranslator;
+import net.minecraft.launchwrapper.Launch;
+
 import org.objectweb.asm.tree.*;
 
 import java.util.Iterator;
@@ -96,7 +98,8 @@ public final class NetServerHandlerTransformer extends TransformerBase {
                             "mods/battlegear2/api/core/BattlegearUtils",
                             "setPlayerCurrentItem", "(L" + entityPlayerClassName + ";L" + itemStackClassName + ";)V"));
                     
-                    if(!FMLCommonHandler.instance().getModName().contains("mcpc")){//MCPC already adds a fix for this
+                    // MCPC and Minecraft Forkage already add fixes for this
+                    if(!FMLCommonHandler.instance().getModName().contains("mcpc") && !Launch.blackboard.containsKey("IsForkage")){
 	                    int slotIndex = 0;
                         while(it.hasNext()){
 	                    	nextNode = it.next();

--- a/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/TransformerBase.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/TransformerBase.java
@@ -3,6 +3,7 @@ package mods.battlegear2.coremod.transformers;
 import mods.battlegear2.api.core.BattlegearTranslator;
 import mods.battlegear2.coremod.BattlegearLoadingPlugin;
 import net.minecraft.launchwrapper.IClassTransformer;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,6 +15,8 @@ import org.objectweb.asm.tree.*;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.Iterator;
 import java.util.List;
 
@@ -41,13 +44,20 @@ public abstract class TransformerBase implements IClassTransformer, Opcodes{
             boolean success = processFields(cn.fields) && processMethods(cn.methods);
             addInterface(cn.interfaces);
             
-			ClassWriter cw = new ClassWriter(0);
+			ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
             cn.accept(cw);
 
             logger.log(success ?Level.INFO:Level.ERROR, "M&B - Patching Class " + unobfClass + (success ? " done" : " FAILED!"));
             if (!success && BattlegearTranslator.debug) {
                 writeClassFile(cw, unobfClass+" ("+name+")");
             }
+            
+            if(name.contains("NetHandlerPlayServer")) {
+            	try (OutputStream out = new FileOutputStream("NetHandlerPlayServer.class")) {
+            		out.write(cw.toByteArray());
+            	} catch(Exception e) {throw new RuntimeException(e);}
+            }
+            
 			return cw.toByteArray();
 
         } else

--- a/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/TransformerBase.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/coremod/transformers/TransformerBase.java
@@ -3,7 +3,6 @@ package mods.battlegear2.coremod.transformers;
 import mods.battlegear2.api.core.BattlegearTranslator;
 import mods.battlegear2.coremod.BattlegearLoadingPlugin;
 import net.minecraft.launchwrapper.IClassTransformer;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,8 +14,6 @@ import org.objectweb.asm.tree.*;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.util.Iterator;
 import java.util.List;
 
@@ -50,12 +47,6 @@ public abstract class TransformerBase implements IClassTransformer, Opcodes{
             logger.log(success ?Level.INFO:Level.ERROR, "M&B - Patching Class " + unobfClass + (success ? " done" : " FAILED!"));
             if (!success && BattlegearTranslator.debug) {
                 writeClassFile(cw, unobfClass+" ("+name+")");
-            }
-            
-            if(name.contains("NetHandlerPlayServer")) {
-            	try (OutputStream out = new FileOutputStream("NetHandlerPlayServer.class")) {
-            		out.write(cw.toByteArray());
-            	} catch(Exception e) {throw new RuntimeException(e);}
             }
             
 			return cw.toByteArray();


### PR DESCRIPTION
This PR makes this mod use SRG names in its transformers. Coremods with a SortingIndex greater than 1000 run after deobfuscation, and therefore see SRG names. Coremods with a SortingIndex less than 1000 (the default) run before deobfuscation and see fully obfuscated names.

In Minecraft Forkage (a fork of Forge), obfuscated names do not exist - the game is loaded with SRG names, so otherwise this mod is incompatible with Minecraft Forkage. (This PR does *not* make the mod rely on Minecraft Forkage, or anything like that. The ability to use SRG names exists in Forge too)

To clarify, this is *not* a Forkage-specific feature; the mod with this PR should still work in Forge.

As a bonus, this makes a whole bunch of code redundant, and so I've removed it.