### PR TITLE
Modification of AbstractMBArrow.java for compatibility with mod entities that extend InventoryPlayer

### DIFF
--- a/battlegear mod src/minecraft/mods/battlegear2/items/arrows/AbstractMBArrow.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/items/arrows/AbstractMBArrow.java
@@ -84,23 +84,19 @@ public abstract class AbstractMBArrow extends EntityArrow {
     public boolean tryPickArrow(EntityPlayer player){
         ItemStack arrow = getPickedUpItem();
         if(arrow!=null){
-        	if (player.inventory instanceof InventoryPlayerBattle)
-        	{
-            		ItemStack offhand = ((InventoryPlayerBattle)player.inventory).getCurrentOffhandWeapon();
-            		if(offhand!=null && offhand.getItem() instanceof IArrowContainer2){
-                		final int size = arrow.stackSize;
-                		ItemStack arrowLeft = ((IArrowContainer2) offhand.getItem()).addArrows(offhand, arrow);
-                		if(arrowLeft==null||arrowLeft.stackSize<size){
-                    			if(arrowLeft!=null && arrowLeft.stackSize>0)
-                        		worldObj.spawnEntityInWorld(new EntityItem(worldObj, posX, posY, posZ, arrowLeft));
-                    			return true;
-                		}
-            		}
+            if (player.inventory instanceof InventoryPlayerBattle)
+            {
+		ItemStack offhand = ((InventoryPlayerBattle)player.inventory).getCurrentOffhandWeapon();
+            	if(offhand!=null && offhand.getItem() instanceof IArrowContainer2){
+                    final int size = arrow.stackSize;
+                    ItemStack arrowLeft = ((IArrowContainer2) offhand.getItem()).addArrows(offhand, arrow);
+                    if(arrowLeft==null||arrowLeft.stackSize<size){
+                	if(arrowLeft!=null && arrowLeft.stackSize>0)
+                            worldObj.spawnEntityInWorld(new EntityItem(worldObj, posX, posY, posZ, arrowLeft));
+                    	    return true;
+                    }
             	}
-            	else
-            	{
-            		return true;
-            	}
+            }
         }
         return player.inventory.addItemStackToInventory(arrow);
     }

--- a/battlegear mod src/minecraft/mods/battlegear2/items/arrows/AbstractMBArrow.java
+++ b/battlegear mod src/minecraft/mods/battlegear2/items/arrows/AbstractMBArrow.java
@@ -84,16 +84,23 @@ public abstract class AbstractMBArrow extends EntityArrow {
     public boolean tryPickArrow(EntityPlayer player){
         ItemStack arrow = getPickedUpItem();
         if(arrow!=null){
-            ItemStack offhand = ((InventoryPlayerBattle)player.inventory).getCurrentOffhandWeapon();
-            if(offhand!=null && offhand.getItem() instanceof IArrowContainer2){
-                final int size = arrow.stackSize;
-                ItemStack arrowLeft = ((IArrowContainer2) offhand.getItem()).addArrows(offhand, arrow);
-                if(arrowLeft==null||arrowLeft.stackSize<size){
-                    if(arrowLeft!=null && arrowLeft.stackSize>0)
-                        worldObj.spawnEntityInWorld(new EntityItem(worldObj, posX, posY, posZ, arrowLeft));
-                    return true;
-                }
-            }
+        	if (player.inventory instanceof InventoryPlayerBattle)
+        	{
+            		ItemStack offhand = ((InventoryPlayerBattle)player.inventory).getCurrentOffhandWeapon();
+            		if(offhand!=null && offhand.getItem() instanceof IArrowContainer2){
+                		final int size = arrow.stackSize;
+                		ItemStack arrowLeft = ((IArrowContainer2) offhand.getItem()).addArrows(offhand, arrow);
+                		if(arrowLeft==null||arrowLeft.stackSize<size){
+                    			if(arrowLeft!=null && arrowLeft.stackSize>0)
+                        		worldObj.spawnEntityInWorld(new EntityItem(worldObj, posX, posY, posZ, arrowLeft));
+                    			return true;
+                		}
+            		}
+            	}
+            	else
+            	{
+            		return true;
+            	}
         }
         return player.inventory.addItemStackToInventory(arrow);
     }


### PR DESCRIPTION
This should allow entities that have inventories extending InventoryPlayer to pick up arrows without causing a casting error with InventoryPlayerBattle that leads to a crash.
Ex: [LittleMaidMob](https://github.com/Legojer/LittleMaidMobEnhanced/issues/4) 